### PR TITLE
fix(syntax): support multiple leading periods for block titles

### DIFF
--- a/syntax/asciidoc.vim
+++ b/syntax/asciidoc.vim
@@ -143,8 +143,8 @@ syn match asciidocDefList "^.\{-}::\%(\s\|$\)" contains=@Spell
 syn match asciidocCallout "\s\+\zs<\%(\.\|\d\+\)>\ze\s*$" contained
 syn match asciidocCalloutDesc "^\s*\zs<\%(\.\|\d\+\)>\ze\s\+"
 
-
-syn match asciidocCaption "^\.[^.[:space:]].*$" contains=@asciidocInline,@Spell
+syn match asciidocCaption "^\.\.\?[^.[:space:]].*$" contains=@asciidocInline,@Spell
+syn match asciidocCaption "^\.\.\?{[[:alpha:]][[:alnum:]-_:]\{-}}.*$" contains=@asciidocInline,@Spell
 
 syn match asciidocBlockOptions "^\[.\{-}\]\s*$"
 


### PR DESCRIPTION
In [commit 4a8968b](https://github.com/asciidoctor/asciidoctor/commit/4a8968b7c5de05cb49459ab59426ec8102f4ba8f), AsciiDoctor added support for a block title having two leading periods. This is mainly useful for cases where a block title refers to a filename starting with a period, e.g. `.vimrc`.

A workaround also exists for having an arbitrary number of leading periods, namely, inserting an attribute reference that refers to either nothing, or a period (e.g. `{empty}`, `{dot}`) directly after the first or second period. Since Vim syntax highlighting can't guess at the value of an attribute reference, we simply assume that any attribute reference following the pattern `^\.\.\?` will resolve to a block title (I can't imagine many scenarios where such a sequence would be intended to yield something other than a block title).